### PR TITLE
Make migrant executable available in project root

### DIFF
--- a/bin/migrant
+++ b/bin/migrant
@@ -1,39 +1,40 @@
 #!/usr/bin/env php
 <?php
 
-/*
- * Attempt to load a composer autoload file, either by searching as if this file is
- * included in the composer file structure (/vendor/fluxoft/migrant/bin) or as if this
- * file is being run as part of a stand-alone installation.
+/**
+ * Finds and requires the Composer autoloader if available.
  */
+function loadAutoloader() {
+	// Check the vendor autoload paths at different levels
+	$autoloadPaths = [
+		__DIR__ . '/vendor/autoload.php',
+		__DIR__ . '/../vendor/autoload.php',
+		__DIR__ . '/../../vendor/autoload.php',
+		__DIR__ . '/../../../vendor/autoload.php',
+		__DIR__ . '/../../../../vendor/autoload.php'
+	];
 
-$autoLoader = false;
-
-$files = [
-	__DIR__ . '/../autoload.php', // composer dependency (called from /vendor/bin dir)
-	__DIR__ . '/../../../autoload.php', // composer dependency (called from /vendor/fluxoft/migrant/bin - not recommended)
-	__DIR__ . '/../vendor/autoload.php', // stand-alone package (assuming one level deep, e.g. /migrations)
-	__DIR__ . '/../vendor/autoload.php' // stand-alone package (assuming two levels deep, e.g. /deploy/db)
-];
-
-foreach ($files as $file) {
-	if (is_file($file)) {
-		$autoLoader = true;
-		require_once($file);
-		break;
+	foreach ($autoloadPaths as $path) {
+		if (file_exists($path)) {
+			require_once $path;
+			return true;
+		}
 	}
+	return false;
 }
 
-if (!$autoLoader) {
-	die("\nMigrant must be installed as a Composer package.\n\n");
+// Attempt to load the autoloader
+if (!loadAutoloader()) {
+	die("\nMigrant must be installed as a Composer package within a project.\n\n");
 }
 
+// Proceed with the rest of the script
 $workingFolder = getcwd();
 
 try {
-   $arguments = $argv;
-   array_shift($arguments); // the first argument is always the name of the script
-   $migrantWorker = new \Fluxoft\Migrant\Worker();
+	$arguments = $argv;
+	array_shift($arguments); // the first argument is always the name of the script
+	$migrantWorker = new \Fluxoft\Migrant\Worker();
 	$migrantWorker->Work($arguments, $workingFolder);
 } catch (\Exception $e) {
 	\Fluxoft\Migrant\Printer::PrintException($e);

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,9 @@
 	"autoload": {
 		"psr-4": { "Fluxoft\\Migrant\\": "src/" }
 	},
-	"bin": ["bin/migrant"]
+	"bin": ["bin/migrant"],
+	"scripts": {
+		"post-install-cmd": ["Fluxoft\\Migrant\\Setup::runCopy"],
+		"post-update-cmd": ["Fluxoft\\Migrant\\Setup::runCopy"]
+	}
 }

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Fluxoft\Migrant;
+
+class Setup {
+	// Static wrapper for Composer's post-install script
+	public static function runCopy() {
+		echo "Running post-install setup...\n"; // debugging output
+		$instance = new self();
+		$instance->copyToProjectRoot();
+	}
+
+	// Main logic, kept non-static for testability
+	public function copyToProjectRoot() {
+		$destinationPath = getcwd() . '/migrant';
+
+		// Content for the new root-level 'migrant' script
+		$scriptContent = <<<'PHP'
+#!/usr/bin/env php
+<?php
+require __DIR__ . '/vendor/bin/migrant';
+PHP;
+
+		// Write the wrapper script to the project root
+		file_put_contents($destinationPath, $scriptContent);
+		echo "Root-level 'migrant' script created successfully.\n";
+
+		// Attempt to make the script executable
+		if (!chmod($destinationPath, 0755)) {
+			echo "Warning: Could not make 'migrant' executable. Please check permissions.\n";
+		}
+	}
+}


### PR DESCRIPTION
Changes the method a bit for locating the composer autoloader. Upon post-install or post-update, creates a script that requires vendor/bin/migrant so it is available from the root, then if possible, makes it executable. This will allow us to run migrant from the project root rather than needing to call it from vendor/bin/migrant